### PR TITLE
 Add command-line options to Config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2,12 +2,15 @@ use error::Result;
 use std::fmt::Debug;
 use std::fs::File;
 use std::io::Read;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use toml;
 
-// XXX make some of them optional
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Config {
+    pub force: Option<bool>,
+    pub in_dir: Option<PathBuf>,
+    pub out_dir: Option<PathBuf>,
+
     pub title: String,
 }
 


### PR DESCRIPTION
Now we can pass Config around the functions, which will be responsible for grouping the command-line options so that we don't need to pass separate options.