### PR TITLE
Refine site generating

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2,14 +2,14 @@ use error::Result;
 use std::fmt::Debug;
 use std::fs::File;
 use std::io::Read;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use toml;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Config {
     pub force: Option<bool>,
-    pub in_dir: Option<PathBuf>,
-    pub out_dir: Option<PathBuf>,
+    pub in_dir: Option<String>,
+    pub out_dir: Option<String>,
 
     pub title: String,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,17 @@ pub struct Config {
     pub title: String,
 }
 
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            force: None,
+            in_dir: None,
+            out_dir: None,
+            title: "Default Title".to_string(),
+        }
+    }
+}
+
 impl Config {
     pub fn from_file<P>(path: P) -> Result<Self>
             where P: AsRef<Path> + Debug {

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -1,36 +1,13 @@
-use chrono::Datelike;
 use config::Config;
 use error::{Error, Result};
 use post::Post;
 use std::env;
 use std::fs::{self, DirBuilder};
 use std::io::Write;
+use std::path::PathBuf;
 use tera::{Context, Tera};
 
-fn output_post(post: &Post, config: &Config, content: &[u8]) -> Result<()> {
-    let pwd = env::current_dir()?;
-    let out_dir = config.out_dir
-        .as_ref()
-        .unwrap_or(&pwd);
-
-    let dirname = format!("{}/{}/{}",
-                          post.meta.ts.year(),
-                          post.meta.ts.month(),
-                          post.meta.ts.day());
-
-    DirBuilder::new()
-        .recursive(true)
-        .create(&dirname)
-        .map_err(|e| format!("fail to create {}: {}", &dirname, e))?;
-
-    let mut filename = out_dir
-        .join(&dirname)
-        .join(&post.meta.link);
-
-    if !filename.set_extension("html") {
-        return Err(Error::new(format!("bad output filename {:?}", filename)));
-    }
-
+fn write_file(filename: PathBuf, config: &Config, content: &[u8]) -> Result<()> {
     let mut out = ::get_opener(config.force.unwrap_or(false))
         .open(&filename)
         .map_err(|e| format!("fail to create {:?}: {}", &filename, e))?;
@@ -40,44 +17,87 @@ fn output_post(post: &Post, config: &Config, content: &[u8]) -> Result<()> {
     Ok(())
 }
 
-fn render_post(post: &Post, config: &Config, tera: &Tera) -> Result<String> {
-    let mut ctx = Context::new();
-    ctx.add("post", post);
-    ctx.add("config", config);
+fn generate_posts(tera: &Tera, base: &Context, config: &Config, posts: &Vec<Post>) -> Result<()> {
+    let out_dir = config.out_dir
+                        .as_ref()
+                        .map(|s| PathBuf::from(s))
+                        .unwrap_or(env::current_dir()?);
 
-    tera.render(::INDEX_FILE, &ctx)
-        .map_err(|e| Error::new(format!("fail to render {:?}: {}", post.path, e)))
+    for post in posts {
+        if post.meta.is_article {
+            println!("rendering article {:?}", post.meta.link);
+        }
+        else {
+            println!("rendering page {:?}", post.meta.link);
+        }
+
+        // XXX it would be better if tera supports editing context
+        let mut ctx = Context::new();
+        ctx.extend(base.clone());
+        ctx.add("post", &post);
+
+        let rendered = tera.render(::POST_FILE, &ctx)
+            .map_err(|e| Error::new(format!("fail to render {:?}: {}", post.path, e)))?;
+
+        let mut filename = if post.meta.is_article {
+            let dir = post.meta.ts.format("%Y/%m/%d").to_string();
+            DirBuilder::new()
+                .recursive(true)
+                .create(&dir)
+                .map_err(|e| format!("fail to create {}: {}", &dir, e))?;
+
+            out_dir.join(&dir).join(&post.meta.link)
+        }
+        else {
+            out_dir.join(&post.meta.link)
+        };
+
+        if !filename.set_extension("html") {
+            return Err(Error::new(format!("bad output filename {:?}", filename)));
+        }
+
+        write_file(filename, config, rendered.as_bytes())?;
+    }
+
+    Ok(())
 }
 
 pub fn generate(config: Config) -> Result<()> {
-    let pwd = env::current_dir()?;
-
     let in_dir = config.in_dir
-        .as_ref()
-        .unwrap_or(&pwd);
+                       .as_ref()
+                       .map(|s| PathBuf::from(s))
+                       .unwrap_or(env::current_dir()?);
 
+    // compile templates
     let tera = Tera::new(in_dir.join(::TEMPLATES_DIR)
                                .join("*")
                                .to_str()
                                .ok_or(Error::new("cannot get templates".to_string()))?)
         .map_err(|e| format!("compile templates fails: {}", e))?;
 
-    let mut latest_post = None;
-
+    // gather articles
+    let mut articles = vec![];
     for entry in fs::read_dir(in_dir.join(::ARTICLES_DIR))? {
-        let entry = entry?;
-        let post = Post::from_file(&entry.path())?;
-
-        println!("rendering {:?}", &entry.path());
-
-        render_post(&post, &config, &tera)
-            .and_then(|c| output_post(&post, &config, c.as_bytes()))?;
-
-        latest_post = match latest_post {
-            None => Some(post),
-            Some(p) => Some(if post.meta.ts > p.meta.ts { post } else { p })
-        };
+        articles.push(Post::from_file(&entry?.path())?);
     }
+    articles.sort_by(|x, y| y.meta.ts.cmp(&x.meta.ts));
+
+    // gather pages
+    let mut pages = vec![];
+    for entry in fs::read_dir(in_dir.join(::PAGES_DIR))? {
+        pages.push(Post::from_file(&entry?.path())?);
+    }
+    pages.sort_by(|x, y| y.meta.ts.cmp(&x.meta.ts));
+
+    // prepare context
+    let mut ctx = Context::new();
+    ctx.add("articles", &articles);
+    ctx.add("pages", &pages);
+    ctx.add("config", &config);
+
+    // generate articles and pages
+    generate_posts(&tera, &ctx, &config, &articles)?;
+    generate_posts(&tera, &ctx, &config, &pages)?;
 
     Ok(())
 }

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -13,53 +13,47 @@ fn write_file(filename: PathBuf, config: &Config, content: &[u8]) -> Result<()> 
         .map_err(|e| format!("fail to create {:?}: {}", &filename, e))?;
 
     out.write(content)?;
-
     Ok(())
 }
 
-fn generate_posts(tera: &Tera, base: &Context, config: &Config, posts: &Vec<Post>) -> Result<()> {
+fn generate_post(tera: &Tera, base: &Context, config: &Config, post: &Post) -> Result<()> {
     let out_dir = config.out_dir
                         .as_ref()
                         .map(|s| PathBuf::from(s))
                         .unwrap_or(env::current_dir()?);
 
-    for post in posts {
-        if post.meta.is_article {
-            println!("rendering article {:?}", post.meta.link);
-        }
-        else {
-            println!("rendering page {:?}", post.meta.link);
-        }
-
-        // XXX it would be better if tera supports editing context
-        let mut ctx = Context::new();
-        ctx.extend(base.clone());
-        ctx.add("post", &post);
-
-        let rendered = tera.render(::POST_FILE, &ctx)
-            .map_err(|e| Error::new(format!("fail to render {:?}: {}", post.path, e)))?;
-
-        let mut filename = if post.meta.is_article {
-            let dir = post.meta.ts.format("%Y/%m/%d").to_string();
-            DirBuilder::new()
-                .recursive(true)
-                .create(&dir)
-                .map_err(|e| format!("fail to create {}: {}", &dir, e))?;
-
-            out_dir.join(&dir).join(&post.meta.link)
-        }
-        else {
-            out_dir.join(&post.meta.link)
-        };
-
-        if !filename.set_extension("html") {
-            return Err(Error::new(format!("bad output filename {:?}", filename)));
-        }
-
-        write_file(filename, config, rendered.as_bytes())?;
+    if post.meta.is_article {
+        println!("generating article {:?}", post.path);
+    }
+    else {
+        println!("generating page {:?}", post.path);
     }
 
-    Ok(())
+    let mut ctx = Context::new();
+    ctx.extend(base.clone());
+    ctx.add("post", post);
+
+    let rendered = tera.render(::POST_FILE, &ctx)
+        .map_err(|e| Error::new(format!("fail to generate {:?}: {}", post.path, e)))?;
+
+    let mut filename = if post.meta.is_article {
+        let dir = post.meta.ts.format("%Y/%m/%d").to_string();
+        DirBuilder::new()
+            .recursive(true)
+            .create(&dir)
+            .map_err(|e| format!("fail to create {}: {}", &dir, e))?;
+
+        out_dir.join(&dir).join(&post.meta.link)
+    }
+    else {
+        out_dir.join(&post.meta.link)
+    };
+
+    if !filename.set_extension("html") {
+        return Err(Error::new(format!("bad output filename {:?}", filename)));
+    }
+
+    write_file(filename, config, rendered.as_bytes())
 }
 
 pub fn generate(config: Config) -> Result<()> {
@@ -96,8 +90,17 @@ pub fn generate(config: Config) -> Result<()> {
     ctx.add("config", &config);
 
     // generate articles and pages
-    generate_posts(&tera, &ctx, &config, &articles)?;
-    generate_posts(&tera, &ctx, &config, &pages)?;
+    for post in articles.iter().chain(pages.iter()) {
+        generate_post(&tera, &ctx, &config, &post)?;
+    }
+
+    // generate archive
+    println!("generating {}", ::ARCHIVE_FILE);
+    tera.render(::ARCHIVE_FILE, &ctx)
+        .map_err(|e| Error::new(format!("fail to generate {}: {}", ::ARCHIVE_FILE, e)))
+        .and_then(|rendered| write_file(PathBuf::from(::ARCHIVE_FILE),
+                                        &config,
+                                        rendered.as_bytes()))?;
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,6 @@ pub const SITE_DIRS:  &[&str] = &[
 
 pub const SITE_FILES: &[&str] = &[
     NOJEKYLL_FILE,
-    CONFIG_FILE
 ];
 
 pub const SITE_TEMPLATES: &[(&str, &[u8])] = &[

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,11 +64,11 @@ pub const ARCHIVE_HTML: &[u8] = b"\
   <meta charset=\"utf-8\">
 </head>
 <body>
-  <h1><a href=\"/\">{{ post.meta.title }}</a></h1>
+  <h1><a href=\"/\">{{ config.title }}</a></h1>
   <div>
     <ul>
-    {% for post in articles %}
-      <li><a href=\"/\">{{ post.meta.title }}</a></li>
+    {% for article in articles %}
+      <li><a href=\"/\">{{ article.meta.title }}</a></li>
     {% endfor %}
     </ul>
   </div>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ pub const SITE_FILES: &[&str] = &[
 
 pub const SITE_TEMPLATES: &[(&str, &[u8])] = &[
     (POST_FILE,    POST_HTML),
+    (INDEX_FILE,   INDEX_HTML),
     (ARCHIVE_FILE, ARCHIVE_HTML),
 ];
 
@@ -53,6 +54,25 @@ pub const POST_HTML: &[u8] = b"\
       {{ post.content }}
     </div>
   </div>
+</body>
+</html>
+";
+
+pub const INDEX_HTML: &[u8] = b"\
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset=\"utf-8\">
+</head>
+<body>
+  {% if latest_article %}
+  <h1><a href=\"/\">{{ latest_article.meta.title }}</a></h1>
+  <div>
+    <div>
+      {{ latest_article.content }}
+    </div>
+  </div>
+  {% endif %}
 </body>
 </html>
 ";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,20 +35,19 @@ pub const SITE_FILES: &[&str] = &[
 ];
 
 pub const SITE_TEMPLATES: &[(&str, &[u8])] = &[
-    (INDEX_FILE,   INDEX_HTML),
-    (POST_FILE,    INDEX_HTML),
+    (POST_FILE,    POST_HTML),
     (ARCHIVE_FILE, ARCHIVE_HTML),
 ];
 
 // HTML for the default template
-pub const INDEX_HTML: &[u8] = b"\
+pub const POST_HTML: &[u8] = b"\
 <!DOCTYPE html>
 <html>
 <head>
   <meta charset=\"utf-8\">
 </head>
 <body>
-  <h1><a href=\"/\">{{ config.title }}</a></h1>
+  <h1><a href=\"/\">{{ post.meta.title }}</a></h1>
   <div>
     <div>
       {{ post.content }}
@@ -65,11 +64,11 @@ pub const ARCHIVE_HTML: &[u8] = b"\
   <meta charset=\"utf-8\">
 </head>
 <body>
-  <h1><a href=\"/\">{{ config.title }}</a></h1>
+  <h1><a href=\"/\">{{ post.meta.title }}</a></h1>
   <div>
     <ul>
-    {% for post in posts %}
-      <li><a href=\"/\">{{ post.title }}</a></li>
+    {% for post in articles %}
+      <li><a href=\"/\">{{ post.meta.title }}</a></li>
     {% endfor %}
     </ul>
   </div>

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,11 +23,21 @@ fn create_site(m: &Matches) -> Result<()> {
 
     let opener = get_opener(m.opt_present("force"));
 
+    // create a default configuration file
+    let config: Config = Default::default();
+    let config = toml::to_string(&config)?;
+    opener.open(dir.join(izzet::CONFIG_FILE))
+          .and_then(|mut f| f.write(config.as_bytes()))
+          .map_err(|e| format!("fail to create {}: {}", izzet::CONFIG_FILE, e))?;
+
+    // create other files
+    // XXX may need to do more things here later
     for filename in izzet::SITE_FILES {
         opener.open(dir.join(filename))
               .map_err(|e| format!("fail to create {}: {}", filename, e))?;
     }
 
+    // create directories
     for dirname in izzet::SITE_DIRS {
         DirBuilder::new()
             .recursive(m.opt_present("force"))
@@ -35,6 +45,7 @@ fn create_site(m: &Matches) -> Result<()> {
             .map_err(|e| format!("fail to create {}: {}", dirname, e))?;
     }
 
+    // create default templates
     for &(filename, html) in izzet::SITE_TEMPLATES {
         let mut file = opener.open(dir.join(izzet::TEMPLATES_DIR)
                                       .join(filename))

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,12 +129,20 @@ fn main() {
     }
 
     let mutex_opts = ["new", "article", "gen", "page"];
-    if mutex_opts.iter()
-        .map(|o| matches.opt_present(o) as u32)
-        .sum::<u32>() != 1 {
-        eprintln!("only one of `-n', `-a' and `-g' could be specified");
-        process::exit(1);
-    }
+
+    match mutex_opts.iter()
+                    .map(|o| matches.opt_present(o) as u32)
+                    .sum::<u32>() {
+        0 => {
+            println!("nothing to do.");
+            process::exit(1);
+        },
+        1 => (),
+        _ => {
+            eprintln!("only one of `-n', `-a', `-p' and `-g' could be specified");
+            process::exit(1);
+        }
+    };
 
     if let Err(e) = run(matches) {
         eprintln!("{}", e);

--- a/src/post.rs
+++ b/src/post.rs
@@ -41,7 +41,7 @@ impl Default for Post {
         Post {
             meta: Default::default(),
             path: Default::default(),
-            content: "".to_string(),
+            content: String::new(),
         }
     }
 }

--- a/src/post.rs
+++ b/src/post.rs
@@ -15,6 +15,7 @@ pub struct PostMeta {
     pub title: String,
     pub link: String,
     pub ts: DateTime<Local>,
+    pub is_article: bool,
 }
 
 impl Default for PostMeta {
@@ -23,6 +24,7 @@ impl Default for PostMeta {
             title: "Default Title".to_string(),
             link: "default-link".to_string(),
             ts: Local::now(),
+            is_article: true,
         }
     }
 }
@@ -80,7 +82,7 @@ impl Post {
     }
 }
 
-pub fn create_post(link: String, config: Config) -> Result<()> {
+pub fn create_post(link: String, config: Config, is_article: bool) -> Result<()> {
     let filename = format!("{}.md", link);
     let opener = ::get_opener(config.force.unwrap_or(false));
     let mut file = opener.open(&filename)
@@ -88,6 +90,7 @@ pub fn create_post(link: String, config: Config) -> Result<()> {
 
     let mut post = Post::new();
     post.meta.link = link;
+    post.meta.is_article = is_article;
 
     file.write(toml::to_string(&post.meta)?.as_bytes())?;
     file.write(POST_META_END.as_bytes())?;


### PR DESCRIPTION
Now we can generate:

- articles in `articles` folder, output in folders like `2017/01/01/x.html`
- pages in `pages` folder, output in site root
- `index.html`, output in site root
- `archive.html`, output in site root