### PR TITLE
Refactor error handling

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use std::{fmt, io, result, string};
+use std::{error, fmt, io, result, string};
 use tera;
 use toml;
 
@@ -7,71 +7,28 @@ pub struct Error {
     msg: String
 }
 
-pub type Result<T> = result::Result<T, Error>;
-
 impl Error {
     pub fn new(msg: String) -> Self {
         Error { msg }
     }
 }
 
-// XXX macro is your friend
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.msg)
+pub type Result<T> = result::Result<T, Error>;
+
+trait ResultContext<T, E> {
+    fn context(self, s: String) -> Result<T>;
+}
+
+impl<T, E> ResultContext<T, E> for result::Result<T, E>
+        where E: error::Error
+{
+    fn context(self, s: String) -> Result<T> {
+        self.map_err(|e| Error::new(format!("{}: {}", s, e.description())))
     }
 }
 
-impl From<string::String> for Error {
-    fn from(msg: string::String) -> Self {
-        Error { msg }
-    }
-}
-
-impl From<io::Error> for Error {
-    fn from(e: io::Error) -> Self {
-        Error { msg: e.to_string() }
-    }
-}
-
-impl From<toml::de::Error> for Error {
-    fn from(e: toml::de::Error) -> Self {
-        Error { msg: e.to_string() }
-    }
-}
-
-impl From<toml::ser::Error> for Error {
-    fn from(e: toml::ser::Error) -> Self {
-        Error { msg: e.to_string() }
-    }
-}
-
-impl From<tera::Error> for Error {
-    fn from(e: tera::Error) -> Self {
-        Error { msg: e.to_string() }
-    }
-}
-
-impl From<string::FromUtf8Error> for Error {
-    fn from(e: string::FromUtf8Error) -> Self {
-        Error { msg: e.to_string() }
-    }
-}
-
-impl From<::std::str::Utf8Error> for Error {
-    fn from(e: ::std::str::Utf8Error) -> Self {
-        Error { msg: e.to_string() }
-    }
-}
-
-impl From<Box<::std::error::Error + Send + Sync + 'static>> for Error {
-    fn from(e: Box<::std::error::Error + Send + Sync + 'static>) -> Self {
-        Error { msg: e.to_string() }
-    }
-}
-
-impl From<()> for Error {
-    fn from(_: ()) -> Self {
-        Error { msg: "error from tiny_http header parsing".to_string() }
+impl<E: error::Error> From<E> for Error {
+    fn from(e: E) -> Self {
+        Error::new(e.description().to_string())
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,4 @@
-use std::{error, fmt, io, result, string};
-use tera;
-use toml;
+use std::{error, fmt, result};
 
 #[derive(Debug)]
 pub struct Error {
@@ -15,7 +13,7 @@ impl Error {
 
 pub type Result<T> = result::Result<T, Error>;
 
-trait ResultContext<T, E> {
+pub trait ResultContext<T, E> {
     fn context(self, s: String) -> Result<T>;
 }
 
@@ -30,5 +28,11 @@ impl<T, E> ResultContext<T, E> for result::Result<T, E>
 impl<E: error::Error> From<E> for Error {
     fn from(e: E) -> Self {
         Error::new(e.description().to_string())
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.msg)
     }
 }

--- a/src/files.rs
+++ b/src/files.rs
@@ -1,4 +1,4 @@
-use error::Result;
+use error::{Result, ResultContext};
 use std::fs::{create_dir_all, File, OpenOptions};
 use std::io::{Read, Write};
 use std::path::Path;
@@ -18,18 +18,18 @@ pub fn get_opener(force: bool) -> OpenOptions {
 pub fn fread<P: AsRef<Path>>(path: P) -> Result<Vec<u8>> {
     let mut content = vec![];
     File::open(&path).and_then(|mut f| f.read_to_end(&mut content))
-        .map_err(|e| format!("error opening file {:?}: {}", path.as_ref(), e))?;
+        .context(format!("error opening file {:?}", path.as_ref()))?;
     Ok(content)
 }
 
 pub fn fwrite<P: AsRef<Path>>(path: P, data: &[u8], force: bool) -> Result<()> {
     if let Some(dir) = path.as_ref().parent() {
         if !dir.exists() {
-            create_dir_all(dir).map_err(|e| format!("error creating {:?}: {}", path.as_ref(), e))?;
+            create_dir_all(dir).context(format!("error creating {:?}", path.as_ref()))?;
         }
     }
     get_opener(force).open(&path)
         .and_then(|mut f| f.write(data))
-        .map_err(|e| format!("error writing {:?}: {}", path.as_ref(), e))?;
+        .context(format!("error writing {:?}", path.as_ref()))?;
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ extern crate izzet;
 extern crate toml;
 
 use getopts::{Matches, Options};
-use izzet::error::{Error, Result};
+use izzet::error::{Error, Result, ResultContext};
 use izzet::{files, post, server};
 use izzet::conf::Conf;
 use izzet::site::Site;
@@ -20,12 +20,12 @@ fn create_site(m: &Matches) -> Result<()> {
     let dir = m.free.get(1).map(PathBuf::from).unwrap_or(env::current_dir()?);
 
     if !dir.exists() {
-        fs::create_dir_all(&dir).map_err(|e| format!("error creating {:?}: {}", dir, e))?;
+        fs::create_dir_all(&dir).context(format!("error creating {:?}", dir))?;
     }
 
     for d in izzet::SITE_DIRS {
         let p = dir.join(d);
-        fs::create_dir_all(&p).map_err(|e| format!("error creating {:?}: {}", p, e))?;
+        fs::create_dir_all(&p).context(format!("error creating {:?}", p))?;
     }
 
     let conf: Conf = Conf::default();

--- a/src/post.rs
+++ b/src/post.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Local};
 use conf::Conf;
-use error::{Error, Result};
+use error::{Error, Result, ResultContext};
 use files;
 use markdown;
 use std::fs::File;
@@ -67,7 +67,7 @@ impl Post {
 
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Option<Self>> {
         let mut reader = File::open(&path).map(|f| BufReader::new(f))
-            .map_err(|e| format!("error opening {:?}: {}", path.as_ref(), e))?;
+            .context(format!("error opening {:?}", path.as_ref()))?;
 
         let mut meta = "".to_string();
         let mut line = "".to_string();
@@ -83,11 +83,11 @@ impl Post {
         }
 
         let meta: PostMeta = toml::from_str(&meta)
-            .map_err(|e| format!("error parsing metadata of {:?}: {}", path.as_ref(), e))?;
+            .context(format!("error parsing metadata of {:?}", path.as_ref()))?;
 
         let mut content = vec![];
         reader.read_to_end(&mut content)
-              .map_err(|e| format!("error reading content from {:?}: {}", path.as_ref(), e))?;
+              .context(format!("error reading content from {:?}", path.as_ref()))?;
 
         let content = match path.as_ref().extension().and_then(|s| s.to_str()) {
             Some("md") | Some("markdown") =>

--- a/src/server.rs
+++ b/src/server.rs
@@ -12,7 +12,8 @@ fn resp_with_status(req: Request, code: u16) -> Result<()> {
 }
 
 pub fn forever<P: AsRef<Path>>(dir: P, conf: Conf) -> Result<()> {
-    let server = Server::http(("0.0.0.0", conf.port.unwrap_or(::DEFAULT_PORT)))?;
+    let server = Server::http(("0.0.0.0", conf.port.unwrap_or(::DEFAULT_PORT)))
+        .map_err(|e| Error::new(e.description().to_string()))?;
 
     loop {
         let req = server.recv()?;
@@ -31,7 +32,8 @@ pub fn forever<P: AsRef<Path>>(dir: P, conf: Conf) -> Result<()> {
             Ok(f) => {
                 println!("200 - {} {}", req.method().as_str(), req.url());
                 let resp = Response::from_file(f)
-                    .with_header(Header::from_str("Cache-Control: no-cache,no-store,must-revalidate")?);
+                    .with_header(Header::from_str("Cache-Control: no-cache,no-store,must-revalidate")
+                                 .map_err(|_| Error::new("error setting HTTP header".to_string()))?);
                 req.respond(resp)?;
             },
         }


### PR DESCRIPTION
I add `ResultContext` trait and implement it for the `Result` type to help easily adding context for each error.